### PR TITLE
Fixing pycuda unit tests after example script migration

### DIFF
--- a/tests/wd_training/pycuda_tests/test_env_training.py
+++ b/tests/wd_training/pycuda_tests/test_env_training.py
@@ -11,7 +11,7 @@ import warnings
 import torch
 import yaml
 
-from warp_drive.training.example_training_script_pycuda import setup_trainer_and_train
+from warp_drive.training.scripts.example_training_script_pycuda import setup_trainer_and_train
 from warp_drive.training.utils.device_child_process.child_process_base import ProcessWrapper
 from warp_drive.training.utils.distributed_train.distributed_trainer_pycuda import (
     perform_distributed_training,


### PR DESCRIPTION
Hello! I had a test failure running the `python warp_drive/utils/unittests/run_trainer_tests.py` [unit test in the README](https://github.com/salesforce/warp-drive?tab=readme-ov-file#testing-your-installation) from the below error:
```
ImportError while importing test module '/home/usaidm/Documents/ExternalLibs/warp-drive/tests/wd_training/pycuda_tests/test_env_training.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.pyenv/versions/3.8.10/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/wd_training/pycuda_tests/test_env_training.py:14: in <module>
    from warp_drive.training.example_training_script_pycuda import setup_trainer_and_train
E   ModuleNotFoundError: No module named 'warp_drive.training.example_training_script_pycuda'
```
Decided to fix and submit a pull request since it is a small fix. Hope it helps!

After making this change, the unit test succeeds.